### PR TITLE
Update environment.py

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -19,7 +19,7 @@ def before_feature(context, feature):
     desired_cap = setup_desired_cap(CONFIG[INDEX])
     context.browser = webdriver.Remote(
         desired_capabilities=desired_cap,
-        command_executor="https://%s:%s@hub.lambdatest.com:443/wd/hub" % (username, authkey)
+        command_executor="https://%s:%s@hub.lambdatest.com/wd/hub" % (username, authkey)
     )
 
 


### PR DESCRIPTION
Chaning the `hub` URL by removing the `port:433` for connecting to Lambdatest Automation grid. 